### PR TITLE
Support for spaces and parentheses in filenames

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
           <% _.forEach(hotspots, function(hotspot) { %>
             <div class='hotspot'>
               <div class='background-image'
-                style='background-image: url(output/thumbs/128px/<%= hotspot.img %>)'></div>
+                style='background-image: url("output/thumbs/128px/<%= hotspot.img %>")'></div>
               <div><%= hotspot.label %></div>
             </div>
           <% }); %>

--- a/utils/process_images.py
+++ b/utils/process_images.py
@@ -69,7 +69,7 @@ class PixPlot:
     invalid_files = []
     for i in self.image_files:
       try:
-        cmd = 'identify ' + i
+        cmd = 'identify "' + i + '"'
         response = subprocess.check_output(cmd, shell=True)
       except:
         invalid_files.append(i)


### PR DESCRIPTION
Quoting arguments to `convert`, `montage`, `identify` and the HTML CSS `background-image` adds support for filenames with often occurring characters such as spaces and parentheses.